### PR TITLE
Add missing dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,16 @@ git clone --recursive https://github.com/ctralie/TDALabs.git
 
 ## Installing Jupyter Notebook And Other Dependencies
 
-To run these modules, you will need to have jupyter notebook installed with a *Python 3* backend with numpy, scipy, and matplotlib.  The easiest way to install this is with Anaconda:
+To run these modules, you will need to have Jupyter notebook installed with a
+*Python 3* backend with numpy, scipy, and matplotlib, and ipywidgets.  The
+easiest way to install this is with Anaconda:
 
 <a href = "https://www.anaconda.com/download/">https://www.anaconda.com/download/</a>
 
 Once you have downloaded and installed all of these packages, navigate to the root of this repository and type the following commands, which will install dependencies
 
 ~~~~~ bash
+pip install cechmate
 pip install cython
 pip install ripser
 pip install imageio   (for SlidingWindow4-Video only)


### PR DESCRIPTION
## What does this implement/fix?
While trying to run the _Basic Shapes_ and _Wasserstein and Bottleneck_ notebooks, I ran into a few `Module not found` errors. This PR adds the missing dependencies to the README.

## Any other comments?
I would suggest adding either a `requirements.txt` or `environment.yml` file so that users can simply run:

```
# for pip
pip install -r requirements.txt
# for conda
conda env create --file=environment.yml
```

I'm happy to implement this if you want.